### PR TITLE
Made logo visible

### DIFF
--- a/css/care-for-horses.css
+++ b/css/care-for-horses.css
@@ -72,7 +72,7 @@ nav {
 
 .logo {
 	font-size: 2.5rem;
-	color: #fff;
+	/*color: #fff;*/
 	padding: 0.5rem 1.3rem;
 	display: inline-block;
 	letter-spacing: 0.2rem;


### PR DESCRIPTION
The word "Agric" was not visible on this page because both the navigation bar and the logo were white. So I commented out the color attribute in the .logo class.